### PR TITLE
Feature/get pupil wfe

### DIFF
--- a/jasmine_toolkit/__init__.py
+++ b/jasmine_toolkit/__init__.py
@@ -2,3 +2,8 @@
 ''' JASMINE toolkit '''
 
 from .version import version as __version__
+
+
+__all__ = [
+  '__version__',
+]

--- a/jasmine_toolkit/__init__.py
+++ b/jasmine_toolkit/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-''' JASMINE toolkit '''
+"""JASMINE toolkit"""
 
 from .version import version as __version__
 
 
 __all__ = [
-  '__version__',
+    '__version__',
 ]

--- a/jasmine_toolkit/optics/pupil.py
+++ b/jasmine_toolkit/optics/pupil.py
@@ -52,7 +52,8 @@ def __get_obscuration(
 
 
 def get_obscuration(
-        xan=0.0 * u.deg, yan=0.0 * u.deg,
+        xan=0.0 * u.deg,
+        yan=0.0 * u.deg,
         pupil_to_m2_distance=None,
         obscuration_depth=None,
         secondary_radius=None,
@@ -90,26 +91,29 @@ def get_obscuration(
         A two-layer obscuration mask pattern.
     '''
 
-    pupil_to_m2_distance = tel.pupil_to_m2_distance \
-        if pupil_to_m2_distance is None else pupil_to_m2_distance
-    obscuration_depth = tel.obscuration_depth \
-        if obscuration_depth is None else obscuration_depth
+    pupil_to_m2_distance = (
+        tel.pupil_to_m2_distance
+        if pupil_to_m2_distance is None else pupil_to_m2_distance)
+    obscuration_depth = (
+        tel.obscuration_depth
+        if obscuration_depth is None else obscuration_depth)
+
+    options = {
+        'xan': xan,
+        'yan': yan,
+        'secondary_radius': secondary_radius,
+        'n_supports': n_supports,
+        'support_width': support_width,
+        'support_angle_offset': support_angle_offset
+    }
 
     layer0 = __get_obscuration(
-        xan=xan, yan=yan,
-        distance=pupil_to_m2_distance,
-        secondary_radius=secondary_radius, n_supports=n_supports,
-        support_width=support_width, support_angle_offset=support_angle_offset)
+        distance=pupil_to_m2_distance, **options)
     layer1 = __get_obscuration(
-        xan=xan, yan=yan,
-        distance=pupil_to_m2_distance + obscuration_depth,
-        secondary_radius=secondary_radius, n_supports=n_supports,
-        support_width=support_width, support_angle_offset=support_angle_offset)
+        distance=pupil_to_m2_distance + obscuration_depth, **options)
 
-    return poppy.CompoundAnalyticOptic([
-        layer0,
-        layer1
-    ], name='JASMINE obscuration')
+    return poppy.CompoundAnalyticOptic(
+        [layer0, layer1], name='JASMINE obscuration')
 
 
 def get_pupil(
@@ -184,8 +188,5 @@ def get_pupil(
     elif isinstance(wfe, WFEfringe37):
         wfe = wfe.wfe
 
-    return poppy.CompoundAnalyticOptic([
-        wfe,
-        pupil,
-        obscuration
-    ], name=name)
+    return poppy.CompoundAnalyticOptic(
+        [wfe, pupil, obscuration], name=name)

--- a/jasmine_toolkit/optics/pupil.py
+++ b/jasmine_toolkit/optics/pupil.py
@@ -55,8 +55,40 @@ def get_obscuration(
         xan=0.0 * u.deg, yan=0.0 * u.deg,
         pupil_to_m2_distance=None,
         obscuration_depth=None,
-        secondary_radius=None, n_supports=None, support_width=None,
+        secondary_radius=None,
+        n_supports=None,
+        support_width=None,
         support_angle_offset=None):
+    ''' Obtain the obscuration mask at the entrance pupil
+
+    Options:
+        xan: Quantity (angle)
+            X angle (xan) with respect to the optical axis.
+
+        yan: Quantity (angle)
+            Y angle (yan) with respect to the optical axis.
+
+        pupil_to_m2_distance: Quantity (length)
+            Distance from the entrance pupil to the secondary mirror.
+
+        obscuration_depth: Quantity (length)
+            Depth of the obscuration.
+
+        secondary_radius: Quantity (length)
+            Radius of the secondary mirror.
+
+        n_supports: int
+            Number of support struts.
+
+        support_width: Quantity (length)
+            Width of the support struts.
+
+        support_angle_offset: Quantity (angle)
+            Angle offset of the support struts.
+
+    Returns:
+        A two-layer obscuration mask pattern.
+    '''
 
     pupil_to_m2_distance = tel.pupil_to_m2_distance \
         if pupil_to_m2_distance is None else pupil_to_m2_distance
@@ -81,12 +113,56 @@ def get_obscuration(
 
 
 def get_pupil(
+        name='entrance pupil',
         primary_radius=None,
-        xan=0.0 * u.deg, yan=0.0 * u.deg,
-        pupil_to_m2_distance=None, obscuration_depth=None,
-        secondary_radius=None, n_supports=None, support_width=None,
-        support_angle_offset=None, wfe=None):
-    ''' Get the pupil plane '''
+        xan=0.0 * u.deg,
+        yan=0.0 * u.deg,
+        pupil_to_m2_distance=None,
+        obscuration_depth=None,
+        secondary_radius=None,
+        n_supports=None,
+        support_width=None,
+        support_angle_offset=None,
+        wfe=None):
+    ''' Generate a set of optical elements at the pupil plane
+
+    Options:
+        name: str
+            Name of the entrance pupil.
+
+        primary_radius: Quantity (length)
+            Radius of the entrance aperture.
+
+        xan: Quantity (angle)
+            X angle (xan) with respect to the optical axis.
+
+        yan: Quantity (angle)
+            Y angle (yan) with respect to the optical axis.
+
+        pupil_to_m2_distance: Quantity (length)
+            Distance from the entrance pupil to the secondary mirror.
+
+        obscuration_depth: Quantity (length)
+            Depth of the obscuration.
+
+        secondary_radius: Quantity (length)
+            Radius of the secondary mirror.
+
+        n_supports: int
+            Number of support struts.
+
+        support_width: Quantity (length)
+            Width of the support struts.
+
+        support_angle_offset: Quantity (angle)
+            Angle offset of the support struts.
+
+        wfe: ZernikeWFE or WFEfringe37
+            Definition of the wavefront error at the entrance pupil.
+
+    Returns:
+        A compound analytic optic instance for the JASMINE telescope.
+    '''
 
     pupil = __get_pupil(primary_radius=primary_radius)
 
@@ -112,4 +188,4 @@ def get_pupil(
         wfe,
         pupil,
         obscuration
-    ], name='entrance pupil')
+    ], name=name)

--- a/jasmine_toolkit/optics/pupil.py
+++ b/jasmine_toolkit/optics/pupil.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 ''' Definition of the pupil plane '''
 
-import jasmine_toolkit.parameters as p
+import jasmine_toolkit.parameters.telescope as tel
 import poppy
 import numpy as np
 import astropy.units as u
 
-from .wfe import get_wfe_fringe37
+from .wfe import get_wfe_fringe37, WFEfringe37
 
 
 __all__ = [
@@ -18,7 +18,7 @@ __all__ = [
 
 def __get_pupil(primary_radius=None):
     primary_radius = primary_radius \
-        if primary_radius else p.telescope.pupil_radius
+        if primary_radius else tel.pupil_radius
     return poppy.CircularAperture(
         radius=primary_radius, name='JASMINE entrance pupil')
 
@@ -28,13 +28,13 @@ def __get_obscuration(
         secondary_radius=None, n_supports=None, support_width=None,
         support_angle_offset=None):
     secondary_radius = secondary_radius \
-        if secondary_radius else p.telescope.m2_obscuration_radius
+        if secondary_radius else tel.m2_obscuration_radius
     n_supports = n_supports \
-        if n_supports else p.telescope.n_spider
+        if n_supports else tel.n_spider
     support_width = support_width \
-        if support_width else p.telescope.spider_thickness
+        if support_width else tel.spider_thickness
     support_angle_offset = support_angle_offset \
-        if support_angle_offset else p.telescope.spider_angle_offset
+        if support_angle_offset else tel.spider_angle_offset
 
     shift_x = distance * np.tan(xan)
     shift_y = distance * np.tan(yan)
@@ -54,12 +54,12 @@ def get_obscuration(
 
     layer0 = __get_obscuration(
         xan=xan, yan=yan,
-        distance=p.telescope.pupil_to_m2_distance,
+        distance=tel.pupil_to_m2_distance,
         secondary_radius=secondary_radius, n_supports=n_supports,
         support_width=support_width, support_angle_offset=support_angle_offset)
     layer1 = __get_obscuration(
         xan=xan, yan=yan,
-        distance=p.telescope.pupil_to_m2_distance + p.telescope.obscuration_depth,
+        distance=tel.pupil_to_m2_distance + tel.obscuration_depth,
         secondary_radius=secondary_radius, n_supports=n_supports,
         support_width=support_width, support_angle_offset=support_angle_offset)
 
@@ -73,7 +73,7 @@ def get_pupil(
         primary_radius=None,
         xan=0.0 * u.deg, yan=0.0 * u.deg, distance=0.0 * u.mm,
         secondary_radius=None, n_supports=None, support_width=None,
-        support_angle_offset=None):
+        support_angle_offset=None, wfe=None):
     ''' Get the pupil plane '''
 
     pupil = __get_pupil(primary_radius=primary_radius)
@@ -83,11 +83,17 @@ def get_pupil(
         secondary_radius=secondary_radius, n_supports=n_supports,
         support_width=support_width, support_angle_offset=support_angle_offset)
 
-    wfe_fringe = get_wfe_fringe37(
-        xan=xan, yan=yan, primary_radius=primary_radius)
+    if wfe is None:
+        wfe_fringe = get_wfe_fringe37(
+            xan=xan, yan=yan, primary_radius=primary_radius)
+        wfe = wfe_fringe.wfe
+    elif isinstance(wfe, poppy.ZernikeWFE):
+        wfe = wfe.copy()
+    elif isinstance(wfe, WFEfringe37):
+        wfe = wfe.wfe
 
     return poppy.CompoundAnalyticOptic([
-        wfe_fringe.wfe,
+        wfe,
         pupil,
         obscuration
     ], name='entrance pupil')

--- a/jasmine_toolkit/optics/pupil.py
+++ b/jasmine_toolkit/optics/pupil.py
@@ -17,6 +17,8 @@ __all__ = [
 
 
 def __get_pupil(primary_radius=None):
+    ''' Helper function to generata a circular aperture '''
+
     primary_radius = primary_radius \
         if primary_radius else tel.pupil_radius
     return poppy.CircularAperture(
@@ -27,6 +29,8 @@ def __get_obscuration(
         xan=0.0 * u.deg, yan=0.0 * u.deg, distance=0.0 * u.mm,
         secondary_radius=None, n_supports=None, support_width=None,
         support_angle_offset=None):
+    ''' Helper function to generate the secondary obscuration '''
+
     secondary_radius = secondary_radius \
         if secondary_radius else tel.m2_obscuration_radius
     n_supports = n_supports \
@@ -48,18 +52,25 @@ def __get_obscuration(
 
 
 def get_obscuration(
-        xan=0.0 * u.deg, yan=0.0 * u.deg, distance=0.0 * u.mm,
+        xan=0.0 * u.deg, yan=0.0 * u.deg,
+        pupil_to_m2_distance=None,
+        obscuration_depth=None,
         secondary_radius=None, n_supports=None, support_width=None,
         support_angle_offset=None):
 
+    pupil_to_m2_distance = tel.pupil_to_m2_distance \
+        if pupil_to_m2_distance is None else pupil_to_m2_distance
+    obscuration_depth = tel.obscuration_depth \
+        if obscuration_depth is None else obscuration_depth
+
     layer0 = __get_obscuration(
         xan=xan, yan=yan,
-        distance=tel.pupil_to_m2_distance,
+        distance=pupil_to_m2_distance,
         secondary_radius=secondary_radius, n_supports=n_supports,
         support_width=support_width, support_angle_offset=support_angle_offset)
     layer1 = __get_obscuration(
         xan=xan, yan=yan,
-        distance=tel.pupil_to_m2_distance + tel.obscuration_depth,
+        distance=pupil_to_m2_distance + obscuration_depth,
         secondary_radius=secondary_radius, n_supports=n_supports,
         support_width=support_width, support_angle_offset=support_angle_offset)
 
@@ -71,7 +82,8 @@ def get_obscuration(
 
 def get_pupil(
         primary_radius=None,
-        xan=0.0 * u.deg, yan=0.0 * u.deg, distance=0.0 * u.mm,
+        xan=0.0 * u.deg, yan=0.0 * u.deg,
+        pupil_to_m2_distance=None, obscuration_depth=None,
         secondary_radius=None, n_supports=None, support_width=None,
         support_angle_offset=None, wfe=None):
     ''' Get the pupil plane '''
@@ -79,9 +91,13 @@ def get_pupil(
     pupil = __get_pupil(primary_radius=primary_radius)
 
     obscuration = get_obscuration(
-        xan=xan, yan=yan, distance=distance,
-        secondary_radius=secondary_radius, n_supports=n_supports,
-        support_width=support_width, support_angle_offset=support_angle_offset)
+        xan=xan, yan=yan,
+        pupil_to_m2_distance=pupil_to_m2_distance,
+        obscuration_depth=obscuration_depth,
+        secondary_radius=secondary_radius,
+        n_supports=n_supports,
+        support_width=support_width,
+        support_angle_offset=support_angle_offset)
 
     if wfe is None:
         wfe_fringe = get_wfe_fringe37(

--- a/jasmine_toolkit/optics/wfe.py
+++ b/jasmine_toolkit/optics/wfe.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-''' Wavefront error class for Fringe Zernike 37 convention'''
+''' Wavefront error class for Fringe Zernike 37 convention '''
 
 from dataclasses import dataclass, field
 from poppy import ZernikeWFE
@@ -38,7 +38,7 @@ def load_zernike37_model(path=None):
         A function `zernike37` that returns Fringe Zernike coefficients
         at the provided angle pair (xan, yan).
     '''
-    path = path if path \
+    path = path if path is None \
         else __get_resource().joinpath('FringeZernike_2D-s1_jas36xm2.csv')
 
     df = pd.read_csv(path, header=None, index_col=0).T
@@ -50,7 +50,7 @@ def load_zernike37_model(path=None):
         xan, yan, df[f'{n+1}'].array.reshape((21, 21))) for n in range(37)]
 
     def zernike37(xan, yan):
-        ''' Return the Zernike 37 model '''
+        ''' Generate a set of Fringe Zernike 37 coefficients '''
         return np.array([model(xan, yan) for model in models]).ravel()
 
     return zernike37
@@ -79,8 +79,8 @@ def get_wfe_fringe37(
     zernike37 = load_zernike37_model(path=path)
     fringe_coeff = zernike37(xan.to_value('deg'), yan.to_value('deg'))
 
-    primary_radius = primary_radius \
-        if primary_radius else p.telescope.pupil_radius
+    primary_radius = primary_radius if primary_radius is None \
+        else p.telescope.pupil_radius
 
     return WFEfringe37(
         name='default',

--- a/jasmine_toolkit/optics/wfe.py
+++ b/jasmine_toolkit/optics/wfe.py
@@ -27,7 +27,17 @@ def __get_resource():
 
 
 def load_zernike37_model(path=None):
-    ''' Return a wavefront error model in the Fringe Zernike 37 convention '''
+    ''' Return a wavefront error model in the Fringe Zernike 37 convention
+
+    Arguments:
+        path: str (optional)
+            Path to the CSV file containing the Zernike coefficients.
+            If not provided, the default file is used.
+
+    Returns:
+        A function `zernike37` that returns Fringe Zernike coefficients
+        at the provided angle pair (xan, yan).
+    '''
     path = path if path \
         else __get_resource().joinpath('FringeZernike_2D-s1_jas36xm2.csv')
 
@@ -48,7 +58,24 @@ def load_zernike37_model(path=None):
 
 def get_wfe_fringe37(
         xan=0.0 * u.deg, yan=0.0 * u.deg, primary_radius=None, path=None):
-    ''' Return a default WFEfringe37 instance '''
+    ''' Return a default WFEfringe37 instance
+
+    Arguments:
+        xan: Quantity (angle, optional)
+            X angle (xan) with respect to the optical axis.
+
+        yan: Quantity (angle, optional)
+            Y angle (yan) with respect to the optical axis.
+
+        primary_radius: Quantity (optional)
+            Radius of the entrance pupil.
+
+        path: str (optional)
+            Path to the wavefront error definition file.
+
+    Returns:
+        A generated WFEfringe37 instance.
+    '''
     zernike37 = load_zernike37_model(path=path)
     fringe_coeff = zernike37(xan.to_value('deg'), yan.to_value('deg'))
 
@@ -79,16 +106,16 @@ class WFEfringe37:
             When the array length is less than 37, the remaining coefficients
             are assumed to be zeros.
 
-        xan: Quantity
+        xan: Quantity (angle)
             X angle (xan) with respect to the optical axis.
 
-        yan: Quantity
+        yan: Quantity (angle)
             Y angle (yan) with respect to the optical axis.
 
-        wavelength: Quantity
+        wavelength: Quantity (length)
             Reference wavelength of the light.
 
-        radius: Quantity
+        radius: Quantity (length)
             Radius of the entrance pupil of the telescope.
     '''
     name: str
@@ -101,11 +128,13 @@ class WFEfringe37:
 
     @property
     def coeff(self):
+        ''' Zernike coefficients in the Noll's convention '''
         return convert_fringe37_to_noll(
             self.fringe_coeff, centering=self.centering)
 
     @property
     def wfe(self):
+        ''' Zernike wavefront error instance '''
         return ZernikeWFE(
             name=self.name,
             radius=self.radius,

--- a/jasmine_toolkit/optics/wfe.py
+++ b/jasmine_toolkit/optics/wfe.py
@@ -7,7 +7,7 @@ from poppy import ZernikeWFE
 from astropy.units.quantity import Quantity
 from importlib.resources import files
 
-from .. import parameters as  p
+from .. import parameters as p
 from .zernike import convert_fringe37_to_noll
 
 import numpy as np

--- a/jasmine_toolkit/version.py
+++ b/jasmine_toolkit/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-version = '1.0.1'
+version = '1.0.5'

--- a/notebook/jasmine_toolkit
+++ b/notebook/jasmine_toolkit
@@ -1,1 +1,0 @@
-../jasmine_toolkit/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,9 @@ ignore = [
   'E741', # Ambiguous variable name
   'F403', # star imports
 ]
-fixable = ['E']
+unfixable = ['ALL']
 
 [tool.ruff.format]
 quote-style = 'single'
+line-ending = 'lf'
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,21 @@ readme = { file = 'README.md', content-type = 'text/markdown' }
   'telescope/teleff.json',
   'telescope/FringeZernike_2D-s1_jas36xm2.csv'
 ]
+
+[tool.ruff]
+exclude = ['**/test']
+line-length = 79
+indent-width = 4
+
+[tool.ruff.lint]
+select = ['E', 'F', 'W']
+ignore = [
+  'E221', # multiple spaces before operator
+  'E731', # Do not assign a `lambda` expression
+  'E741', # Ambiguous variable name
+  'F403', # star imports
+]
+fixable = ['E']
+
+[tool.ruff.format]
+quote-style = 'single'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ repository = 'https://github.com/JASMINE-Mission/jasmine_toolkit'
 
 
 [tool.setuptools.packages.find]
-include = ['jasmine_toolkit']
+include = ['jasmine_toolkit*']
 
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,8 @@ line-length = 79
 indent-width = 4
 
 [tool.ruff.lint]
-select = ['E', 'F', 'W']
+select = [
+  'E', 'F', 'W']
 ignore = [
   'E221', # multiple spaces before operator
   'E731', # Do not assign a `lambda` expression
@@ -88,3 +89,4 @@ fixable = ['E']
 
 [tool.ruff.format]
 quote-style = 'single'
+preview = true


### PR DESCRIPTION
This pull request primarily focuses on refactoring the `jasmine_toolkit` codebase for better modularity and readability, along with minor updates to the version and project configuration. Key changes include replacing direct imports of `parameters` with `parameters.telescope`, enhancing helper functions, adding flexibility to the pupil generation logic, and updating the version and package inclusion settings.

### Refactoring and modularization:

* **Refactored imports in `jasmine_toolkit/optics/pupil.py`:** Changed the import of `parameters` to `parameters.telescope` for improved modularity and clarity. Also added the `WFEfringe37` import to support new functionality.
* **Enhanced helper functions:** Added docstrings to `__get_pupil` and `__get_obscuration` functions for better documentation, and replaced hardcoded references to `p.telescope` parameters with `tel` equivalents for consistency. [[1]](diffhunk://#diff-a2723e3b3a9adcfdd1940646184528e8b3144d875d9994a362c6c43544b598e5R20-R23) [[2]](diffhunk://#diff-a2723e3b3a9adcfdd1940646184528e8b3144d875d9994a362c6c43544b598e5R32-R41)

### Functional improvements:

* **Improved `get_obscuration` and `get_pupil` functions:** Added support for optional `pupil_to_m2_distance`, `obscuration_depth`, and `wfe` parameters, providing more flexibility in generating the pupil plane. Also introduced logic to handle different types of wavefront errors (`poppy.ZernikeWFE` and `WFEfringe37`). [[1]](diffhunk://#diff-a2723e3b3a9adcfdd1940646184528e8b3144d875d9994a362c6c43544b598e5L51-R73) [[2]](diffhunk://#diff-a2723e3b3a9adcfdd1940646184528e8b3144d875d9994a362c6c43544b598e5L74-R112)

### Version and configuration updates:

* **Updated version in `jasmine_toolkit/version.py`:** Incremented the version from `1.0.1` to `1.0.5` to reflect the changes.
* **Modified package inclusion in `pyproject.toml`:** Updated the `include` field to `['jasmine_toolkit*']` to ensure all submodules are included in the package.